### PR TITLE
WIP: issue 11 code coverage

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -4,17 +4,18 @@ var format = require('util').format
 
 var Promise = require('lie')
 
-var generateSalt = require('./utils/generate-salt')
-var hashPassword = require('./utils/hash-password')
+var internals = module.exports.internals = {}
+internals.hashPassword = require('./utils/hash-password')
+internals.generateSalt = require('./utils/generate-salt')
 
 var NUM_ITERATIONS = 10
 var PASSWORD_SCHEME = 'pbkdf2'
 
 function setAdmin (state, username, password) {
   return new Promise(function (resolve, reject) {
-    var salt = generateSalt()
+    var salt = internals.generateSalt()
 
-    hashPassword(
+    internals.hashPassword(
       password,
       salt,
       NUM_ITERATIONS,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mkdirp": "^0.5.1",
     "pouchdb-adapter-memory": "^6.0.7",
     "pouchdb-core": "^6.0.7",
-    "rewire": "^2.5.2",
+    "proxyquire": "^1.7.10",
     "rimraf": "^2.4.4",
     "semantic-release": "^6.0.3",
     "simple-mock": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "pouchdb-core": "^6.0.7",
     "rimraf": "^2.4.4",
     "semantic-release": "^6.0.3",
+    "simple-mock": "^0.5.0",
     "tap-min": "^1.0.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mkdirp": "^0.5.1",
     "pouchdb-adapter-memory": "^6.0.7",
     "pouchdb-core": "^6.0.7",
+    "rewire": "^2.5.2",
     "rimraf": "^2.4.4",
     "semantic-release": "^6.0.3",
     "simple-mock": "^0.5.0",

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,1 +1,2 @@
 require('./integration/factory-test')
+require('./unit/set-test')

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,2 +1,3 @@
 require('./integration/factory-test')
 require('./unit/set-test')
+require('./unit/utils/admin-hash-to-doc-test')

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,4 @@
-require('./integration/factory-test')
 require('./unit/set-test')
+require('./unit/validate-password-test')
 require('./unit/utils/admin-hash-to-doc-test')
+require('./integration/factory-test')

--- a/tests/integration/factory-test.js
+++ b/tests/integration/factory-test.js
@@ -78,25 +78,3 @@ test('db.admins({secret: "secret123"})', function (t) {
 
   .catch(t.error)
 })
-
-
-var internals = module.exports.internals = {}
-internals.hashPassword = require('../../lib/utils/hash-password')
-
-var simple = require('simple-mock')
-
-test('set.js', function (t) {
-  t.plan(1)
-
-  simple.mock(internals, 'hashPassword').callbackWith(new Error('error'))
-
-  PouchDB.plugin(plugin)
-  var db = new PouchDB('foo')
-  var admins = db.admins({secret: 'secret123'})
-  var results = admins.set('kim', 'secret')
-
-  t.deepEqual(admins.set('kim', 'secret'),results,'reject promise in set.js when hashPassword encounters error')
-
-  simple.restore()
-  t.end()
-})

--- a/tests/integration/factory-test.js
+++ b/tests/integration/factory-test.js
@@ -78,3 +78,25 @@ test('db.admins({secret: "secret123"})', function (t) {
 
   .catch(t.error)
 })
+
+
+var internals = module.exports.internals = {}
+internals.hashPassword = require('../../lib/utils/hash-password')
+
+var simple = require('simple-mock')
+
+test('set.js', function (t) {
+  t.plan(1)
+
+  simple.mock(internals, 'hashPassword').callbackWith(new Error('error'))
+
+  PouchDB.plugin(plugin)
+  var db = new PouchDB('foo')
+  var admins = db.admins({secret: 'secret123'})
+  var results = admins.set('kim', 'secret')
+
+  t.deepEqual(admins.set('kim', 'secret'),results,'reject promise in set.js when hashPassword encounters error')
+
+  simple.restore()
+  t.end()
+})

--- a/tests/unit/set-test.js
+++ b/tests/unit/set-test.js
@@ -1,0 +1,25 @@
+var simple = require('simple-mock')
+var test = require('tape')
+
+var set = require('../../lib/set')
+var internals = set.internals
+
+test('set', function (t) {
+  t.plan(1)
+
+  var state = {}
+  var username = 'admin'
+  var password = 'secret'
+
+  simple.mock(internals, 'hashPassword').callbackWith(new Error('hashPassword error'))
+
+  set(state, username, password)
+
+  .then(function () {
+    t.error('Should reject')
+  })
+
+  .catch(function (error) {
+    t.is(error.message, 'hashPassword error', 'rejects with error from hashPassword')
+  })
+})

--- a/tests/unit/set-test.js
+++ b/tests/unit/set-test.js
@@ -1,25 +1,54 @@
 var simple = require('simple-mock')
 var test = require('tape')
+var format = require('util').format
 
 var set = require('../../lib/set')
 var internals = set.internals
 
-test('set', function (t) {
-  t.plan(1)
-
-  var state = {}
+test('set', function (group) {
+  var state = {admins: {}}
   var username = 'admin'
   var password = 'secret'
 
-  simple.mock(internals, 'hashPassword').callbackWith(new Error('hashPassword error'))
+  group.test('when hashPassword errors', function(t) {
+    t.plan(1)
 
-  set(state, username, password)
+    simple.mock(internals, 'hashPassword').callbackWith(new Error('hashPassword error'))
 
-  .then(function () {
-    t.error('Should reject')
+    set(state, username, password)
+
+      .then(function () {
+        t.error('Should reject')
+      })
+
+      .catch(function (error) {
+        t.is(error.message, 'hashPassword error', 'rejects with error from hashPassword')
+      })
+
+    simple.restore()
   })
 
-  .catch(function (error) {
-    t.is(error.message, 'hashPassword error', 'rejects with error from hashPassword')
+  group.test('when hashPassword succeeds', function(t) {
+    t.plan(1)
+
+    var hash = 'mylonghash'
+    simple.mock(internals, 'hashPassword').callbackWith(null, hash)
+
+    set(state, username, password)
+
+      .then(function () {
+        t.ok((new RegExp(format(
+          '^-pbkdf2-%s,[^,]{48},10$',
+          hash
+        ))).test(state.admins[username]), 'resolves with salted hash string')
+      })
+
+      .catch(function (error) {
+        t.error('Should succeed')
+      })
+
+    simple.restore()
   })
+
+  group.end()
 })

--- a/tests/unit/utils/admin-hash-to-doc-test.js
+++ b/tests/unit/utils/admin-hash-to-doc-test.js
@@ -1,0 +1,32 @@
+var test = require('tape')
+var adminHashToDoc = require('../../../lib/utils/admin-hash-to-doc')
+
+var username = 'myTestAdminUser'
+
+test('admin-hash-to-doc', function (group) {
+
+  group.test('when passed hash does not conform to the expected format', function(t) {
+    t.plan(1)
+    var hash = 'this is just wrong'
+
+    t.equal(adminHashToDoc(username, hash), undefined, 'will return an undefined value')
+  })
+
+  group.test('when passed hash conforms to the expected format', function(t) {
+    t.plan(1)
+    var hash = '-pbkdf2-01234abc,56789def,2000'
+
+    t.deepEqual(adminHashToDoc(username, hash), {
+      _id: 'org.couchdb.user:' + username,
+      type: 'user',
+      name: username,
+      password_scheme: 'pbkdf2',
+      derived_key: '01234abc',
+      salt: '56789def',
+      iterations: 2000,
+      roles: ['_admin']
+    }, 'will return an object with user details')
+  })
+
+  group.end()
+})

--- a/tests/unit/validate-password-test.js
+++ b/tests/unit/validate-password-test.js
@@ -1,0 +1,39 @@
+var simple = require('simple-mock')
+var test = require('tape')
+
+var rewire = require('rewire')
+var validatePassword = rewire('../../lib/validate-password')
+
+var getAdminStub = simple.stub()
+
+test('validate-password', function (group) {
+  group.test('when pbkdf2 errors', function(t) {
+    t.plan(1)
+
+
+    validatePassword.__with__({
+      getAdmin: getAdminStub
+    })(function () {
+      getAdminStub.resolveWith({
+        salt: 'im-salty'
+      })
+      var error = new Error('pbkdf2 error')
+      simple.mock(validatePassword.__get__('crypto'), 'pbkdf2')
+        .callbackAtIndex(4, error)
+
+      validatePassword()
+        .then(function () {
+          t.fail("should not resolve")
+        })
+        .catch(function (caughtError) {
+          t.equal(caughtError, error, "should reject the returned promise with the error thrown from pbkdf2")
+        })
+        .then(function () {
+          simple.restore()
+          getAdminStub.actions = []
+        })
+    })
+  })
+
+  group.end()
+})


### PR DESCRIPTION
This is for issue #11 .
Started working on `set.js` file. The test passes, but code coverage still shows that `if (error) {
          return reject(error)
        }` (line 22 in set.js) isn't covered.
