### PR TITLE
Nvm 'stable' version jump causing travis cache of node_modules to go stale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 sudo: false
 language: node_js
-cache:
-  directories:
-    - node_modules
+cache: false
 notifications:
   email: false
 node_js:
   - '4'
+  - '6'
   - stable
 before_script:
   - npm prune


### PR DESCRIPTION
See [here](https://travis-ci.org/hoodiehq/pouchdb-admins/jobs/172279822#L191) - the package leveldown was fetched for the previous 'stable' version of [v6.9.1 here](https://travis-ci.org/hoodiehq/pouchdb-admins/jobs/169964226) and cached for later. Between then and now the version nvm considers 'stable' has jumped to v7.0.0 and the cached binary module refuses to run against this later version. 